### PR TITLE
Auto-update PostgreSQL versions

### DIFF
--- a/build-all-versions.sh
+++ b/build-all-versions.sh
@@ -2,8 +2,8 @@
 
 # PostgreSQL versions to build
 declare -A POSTGRES_VERSIONS=(
-    ["18"]="18.0 18 latest 18.0-trixie 18-trixie trixie 18.0-bookworm 18-bookworm bookworm"
-    ["17"]="17.6 17 17.6-trixie 17-trixie 17.6-bookworm 17-bookworm"
+    ["18"]="18.4 18 latest 18.4-trixie 18-trixie trixie 18.4-bookworm 18-bookworm bookworm "
+    ["17"]="17.10 17 17.10-trixie 17-trixie 17.10-bookworm 17-bookworm"
 )
 
 # Function to check if Docker image already exists

--- a/check_images.sh
+++ b/check_images.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Source the versions from build script
+source build-all-versions.sh
+
+# Function to check if Docker image already exists
+image_exists() {
+    local image_tag=$1
+    if docker manifest inspect "pshaddel/postgres-pgtap:$image_tag" >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Check if any version needs building
+needs_any_building=false
+for version in "${!POSTGRES_VERSIONS[@]}"; do
+    tags="${POSTGRES_VERSIONS[$version]}"
+    for tag in $tags; do
+        if ! image_exists "$tag"; then
+            echo "Image pshaddel/postgres-pgtap:$tag does not exist, building needed"
+            needs_any_building=true
+            break 2
+        fi
+    done
+done
+
+if [ "$needs_any_building" = true ]; then
+    echo "needs_building=true" >> $GITHUB_OUTPUT
+else
+    echo "needs_building=false" >> $GITHUB_OUTPUT
+    echo "All images already exist, no building needed"
+fi


### PR DESCRIPTION
This PR automatically updates PostgreSQL versions to the latest available.

Updates:
- Updated PostgreSQL 18 to 18.4
- Updated PostgreSQL 17 to 17.10

Build status:
- No image rebuilding was needed (all images already exist)

The build script handles:
- Multi-platform builds (linux/arm/v7, linux/arm64/v8, linux/amd64)
- PostgreSQL 18 special handling (copying pgTAP from PG17)
- All variant tags (bookworm, trixie)
- Skipping builds for images that already exist